### PR TITLE
Fixed Possible Json Ordering Permutations Problem in Tests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,14 +24,14 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@cc7986c02bac29104a72998e67239bb5ee2ee110 # tag=v2
+        uses: github/codeql-action/init@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # tag=v2
         with:
           languages: java
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@cc7986c02bac29104a72998e67239bb5ee2ee110 # tag=v2
+        uses: github/codeql-action/autobuild@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # tag=v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -45,4 +45,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@cc7986c02bac29104a72998e67239bb5ee2ee110 # tag=v2
+        uses: github/codeql-action/analyze@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # tag=v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,14 +24,14 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # tag=v2
+        uses: github/codeql-action/init@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v2
         with:
           languages: java
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # tag=v2
+        uses: github/codeql-action/autobuild@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -45,4 +45,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # tag=v2
+        uses: github/codeql-action/analyze@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,14 +24,14 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # tag=v2
+        uses: github/codeql-action/init@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # tag=v2
         with:
           languages: java
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # tag=v2
+        uses: github/codeql-action/autobuild@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # tag=v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -45,4 +45,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # tag=v2
+        uses: github/codeql-action/analyze@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # tag=v2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 lesscpy==0.15.1
 Sphinx==5.3.0
 sphinx-autobuild==2021.3.14
-sphinx-rtd-theme==1.1.0
+sphinx-rtd-theme==1.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 lesscpy==0.15.1
 Sphinx==5.3.0
 sphinx-autobuild==2021.3.14
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.1.0

--- a/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
+++ b/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
@@ -59,7 +59,7 @@
 #if( $shaded == "true" )
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.4.1</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <transformers>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -58,7 +58,7 @@
         <logback.version>1.2.11</logback.version>
         <metrics4.version>4.2.12</metrics4.version>
         <mustache-compiler.version>0.9.10</mustache-compiler.version>
-        <nullaway.version>0.10.2</nullaway.version>
+        <nullaway.version>0.10.3</nullaway.version>
         <slf4j.version>1.7.36</slf4j.version>
         <tomcat-jdbc.version>9.0.68</tomcat-jdbc.version>
         <usertype.core.version>7.0.0.CR1</usertype.core.version>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -50,7 +50,7 @@
         <jersey.version>2.37</jersey.version>
         <jetty-setuid-java.version>1.0.4</jetty-setuid-java.version>
         <jetty.version>9.4.49.v20220914</jetty.version>
-        <joda-time.version>2.12.0</joda-time.version>
+        <joda-time.version>2.12.1</joda-time.version>
         <jsr305.version>3.0.2</jsr305.version>
         <liquibase-core.version>4.17.1</liquibase-core.version>
         <liquibase-slf4j.version>4.1.0</liquibase-slf4j.version>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -511,12 +511,30 @@
                     <artifactId>pgpverify-maven-plugin</artifactId>
                     <version>${pgpverify-maven-plugin.version}</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>${lifecycle-mapping.version}</version>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>compile-eclipse</id>
+            <activation>
+                <jdk>1.8</jdk>
+                <property>
+                    <name>m2e.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eclipse.m2e</groupId>
+                            <artifactId>lifecycle-mapping</artifactId>
+                            <version>${lifecycle-mapping.version}</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -22,7 +22,7 @@
         <argparse4j.version>0.9.0</argparse4j.version>
         <byte-buddy.version>1.12.18</byte-buddy.version>
         <caffeine.version>2.9.3</caffeine.version>
-        <checker-qual.version>3.26.0</checker-qual.version>
+        <checker-qual.version>3.27.0</checker-qual.version>
         <classmate.version>1.5.1</classmate.version>
         <commons-codec.version>1.15</commons-codec.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -31,7 +31,7 @@
         <error_prone.version>2.10.0</error_prone.version>
         <freemarker.version>2.3.31</freemarker.version>
         <guava.version>31.1-jre</guava.version>
-        <hibernate-core.version>5.6.13.Final</hibernate-core.version>
+        <hibernate-core.version>5.6.14.Final</hibernate-core.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <hk2.version>2.6.1</hk2.version>
         <httpclient.version>4.5.13</httpclient.version>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -31,7 +31,7 @@
         <error_prone.version>2.10.0</error_prone.version>
         <freemarker.version>2.3.31</freemarker.version>
         <guava.version>31.1-jre</guava.version>
-        <hibernate-core.version>5.6.12.Final</hibernate-core.version>
+        <hibernate-core.version>5.6.13.Final</hibernate-core.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <hk2.version>2.6.1</hk2.version>
         <httpclient.version>4.5.13</httpclient.version>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -52,7 +52,7 @@
         <jetty.version>9.4.49.v20220914</jetty.version>
         <joda-time.version>2.12.1</joda-time.version>
         <jsr305.version>3.0.2</jsr305.version>
-        <liquibase-core.version>4.17.1</liquibase-core.version>
+        <liquibase-core.version>4.17.2</liquibase-core.version>
         <liquibase-slf4j.version>4.1.0</liquibase-slf4j.version>
         <logback-throttling-appender.version>1.1.9</logback-throttling-appender.version>
         <logback.version>1.2.11</logback.version>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -58,7 +58,7 @@
         <logback.version>1.2.11</logback.version>
         <metrics4.version>4.2.12</metrics4.version>
         <mustache-compiler.version>0.9.10</mustache-compiler.version>
-        <nullaway.version>0.10.3</nullaway.version>
+        <nullaway.version>0.10.4</nullaway.version>
         <slf4j.version>1.7.36</slf4j.version>
         <tomcat-jdbc.version>9.0.68</tomcat-jdbc.version>
         <usertype.core.version>7.0.0.CR1</usertype.core.version>

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -218,7 +218,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -61,7 +62,7 @@ class JsonHealthResponseProviderTest {
         // then
         assertThat(response.isHealthy()).isTrue();
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-        assertThat(response.getMessage()).isEqualToIgnoringWhitespace(fixture("/json/single-healthy-response.json"));
+        assertEquals(mapper.readTree(response.getMessage()), mapper.readTree(fixture("/json/single-healthy-response.json")));
     }
 
     @Test
@@ -87,7 +88,7 @@ class JsonHealthResponseProviderTest {
         // then
         assertThat(response.isHealthy()).isTrue();
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-        assertThat(response.getMessage()).isEqualToIgnoringWhitespace(fixture("/json/multiple-healthy-responses.json"));
+        assertEquals(mapper.readTree(response.getMessage()), mapper.readTree(fixture("/json/multiple-healthy-responses.json")));
     }
 
     @Test

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -62,7 +61,7 @@ class JsonHealthResponseProviderTest {
         // then
         assertThat(response.isHealthy()).isTrue();
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-        assertEquals(mapper.readTree(response.getMessage()), mapper.readTree(fixture("/json/single-healthy-response.json")));
+        assertThat(mapper.readTree(response.getMessage())).isEqualTo(mapper.readTree(fixture("/json/single-healthy-response.json")));
     }
 
     @Test
@@ -88,7 +87,7 @@ class JsonHealthResponseProviderTest {
         // then
         assertThat(response.isHealthy()).isTrue();
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-        assertEquals(mapper.readTree(response.getMessage()), mapper.readTree(fixture("/json/multiple-healthy-responses.json")));
+        assertThat(mapper.readTree(response.getMessage())).isEqualTo(mapper.readTree(fixture("/json/multiple-healthy-responses.json")));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
         <!-- Plugin versions, see also dropwizard-dependencies -->
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
-        <cyclonedx-maven-plugin.version>2.7.2</cyclonedx-maven-plugin.version>
+        <cyclonedx-maven-plugin.version>2.7.3</cyclonedx-maven-plugin.version>
         <maven-archetype-plugin.version>3.2.1</maven-archetype-plugin.version>
         <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>


### PR DESCRIPTION
# Summary

Following the problem of flakiness that occurred in the test file
`dropwizard-health io.dropwizard.health.response.JsonHealthResponseProviderTest`
with below three tests
```
shouldHandleMultipleHealthStateViewsCorrectly
shouldHandleSingleHealthStateViewCorrectly
```
The test flakiness is due to comparisons between Json Strings and outputs from
`response.getMessage()` which is an Object in JSON format that compare with a JSON file locates in the `resources `file.

However, JsonObject does not guarantee entry orders, its object is an unordered set of name/value pairs, and internal permutations may occur in the output as JSON String.

## Brief changelog

Since JSON library `com.fasterxml.jackson.databind.ObjectMapper` is used in the current project, I use `mapper.readTree(JSON String)` when comparing them, thus the equals() method ignores the order and treats them as equal.

## Verifying this change

This test avoids nested or different orders of JSON strings that cause flaky errors.
Since I didn't touch any Source code, it should be no impact on the project.
And it passed the local test with.`mvn clean install -P contrib-check`
